### PR TITLE
Fix elephant not loading after ASDF-3.1.5 → 3.3.1 upgrade

### DIFF
--- a/elephant.asd
+++ b/elephant.asd
@@ -264,7 +264,7 @@
 	(or (uffi-funcall :load-foreign-library file :module module)
 	    (error "Could not load ~A into ~A" file module)))))
   ;; Load the compiled libraries
-  (dolist (file (output-files (make-instance 'compile-op) c))
+  (dolist (file (output-files (make-operation 'compile-op) c))
     (format t "Attempting to load ~A...~%" (file-namestring file))
     (if (and (probe-file file)
 	     (not (get-config-option :prebuilt-libraries c)))


### PR DESCRIPTION
Your repository seems to be the latest version of elephant alive. So I sent my patch here.

I did not test thoroughly but this change is recommended by ASDF itself, and it makes elephant load with recent ASDF for me.

I'll mention your repository on CLiki as “most current maintained unofficial fork” unless you happen to know of some more recent attempts.